### PR TITLE
Fix 'while true sleep 0' bug on weekends

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -242,7 +242,7 @@ def setup_one_identity_routine(*args):
             print('Waiting for next time to report')
         # calc time until 8:00 am and sleep
         now = datetime.datetime.now()
-        time_to_sleep = (datetime.timedelta(hours=24) - (now-now.replace(hour=START_TIME.hour, minute=START_TIME.minute, second=START_TIME.second))).total_seconds() % (24 * 3600)
+        time_to_sleep = (datetime.timedelta(hours=24) - (now-now.replace(hour=START_TIME.hour, minute=START_TIME.minute, second=START_TIME.second))).total_seconds()
         print('Sleeping for {} hours'.format(time_to_sleep/60/60))
         time.sleep(time_to_sleep)
 


### PR DESCRIPTION
On weekends, `setup_one_identity_routine` runs really fast (because it has nothing to do),  
so when it tries to calculate how much time it needs to sleep it gets exactly 24 hours, which later gets reduced to 0 by the `% (24 * 3600)`  
This causes it to `sleep(0)` for no reason.  
I don't see a reason for the `% (24 * 3600)`, so I simply removed it